### PR TITLE
Quick Fix

### DIFF
--- a/cardinia.rb
+++ b/cardinia.rb
@@ -1,4 +1,4 @@
-require 'scraperwiki'
+#require 'scraperwiki'
 require 'mechanize'
 
 agent = Mechanize.new
@@ -30,9 +30,10 @@ def scrape_page(page, comment_url)
       "date_scraped" => Date.today.to_s
     }
 
-    puts "Saving record " + record['council_reference'] + ", " + record['address']
+    puts "Saving record " + record['council_reference'] + ", " + record['address'] + ", " + record['on_notice_to'] + ", " + record['description']
+    #puts "Saving record " + record['council_reference'] + ", " + record['address']
 #      puts record
-    ScraperWiki.save_sqlite(['council_reference'], record)
+    #ScraperWiki.save_sqlite(['council_reference'], record)
   end
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -4,9 +4,6 @@ require 'mechanize'
 agent = Mechanize.new
 
 def scrape_page(page, comment_url)
-  special = "?<>',?[]}{=-)(*&^%$#`~{}"
-  regex = /[#{special.gsub(/./){|char| "\\#{char}"}}]/
-
   table = page.at("table")
 
   table.search("tr")[1..-1].each do |tr|
@@ -27,7 +24,7 @@ def scrape_page(page, comment_url)
 
     puts "Saving record " + record['council_reference'] + ", " + record['address']
 #      puts record
-    #ScraperWiki.save_sqlite(['council_reference'], record)
+    ScraperWiki.save_sqlite(['council_reference'], record)
   end
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,4 +1,4 @@
-require 'scraperwiki'
+#require 'scraperwiki'
 require 'mechanize'
 
 agent = Mechanize.new
@@ -7,8 +7,8 @@ def scrape_page(page, comment_url)
   table = page.at("table")
 
   table.search("tr")[1..-1].each do |tr|
-    day, month, year = tr.search("td")[3].inner_text.gsub(/[[:space:]]/, ' ').split(" ")
-    month_i = Date::MONTHNAMES.index(month)
+    #day, month, year = tr.search("td")[3].inner_text.gsub(/[[:space:]]/, ' ').split(" ")
+    #month_i = Date::MONTHNAMES.index(month)
 
     record = {
       "info_url" => tr.search("td a")[0].attributes['href'].to_s,
@@ -16,7 +16,7 @@ def scrape_page(page, comment_url)
       "council_reference" => tr.search("td")[0].inner_text,
       "description" => tr.search("td")[1].inner_text,
       "address" => tr.search("td")[2].inner_text + ", VIC",
-      "on_notice_to" => Date.new(year.to_i, month_i, day.to_i).to_s,
+      #"on_notice_to" => Date.new(year.to_i, month_i, day.to_i).to_s,
       "date_scraped" => Date.today.to_s
     }
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,28 +1,33 @@
-#require 'scraperwiki'
+require 'scraperwiki'
 require 'mechanize'
 
 agent = Mechanize.new
 
 def scrape_page(page, comment_url)
+  special = "?<>',?[]}{=-)(*&^%$#`~{}"
+  regex = /[#{special.gsub(/./){|char| "\\#{char}"}}]/
+
   table = page.at("table")
 
   table.search("tr")[1..-1].each do |tr|
     #day, month, year = tr.search("td")[3].inner_text.gsub(/[[:space:]]/, ' ').split(" ")
     #month_i = Date::MONTHNAMES.index(month)
 
+    address = tr.search("td")[2].inner_text + ", VIC"
+
     record = {
       "info_url" => tr.search("td a")[0].attributes['href'].to_s,
       "comment_url" => comment_url,
       "council_reference" => tr.search("td")[0].inner_text,
       "description" => tr.search("td")[1].inner_text,
-      "address" => tr.search("td")[2].inner_text + ", VIC",
+      "address" => address,
       #"on_notice_to" => Date.new(year.to_i, month_i, day.to_i).to_s,
       "date_scraped" => Date.today.to_s
     }
 
     puts "Saving record " + record['council_reference'] + ", " + record['address']
 #      puts record
-    ScraperWiki.save_sqlite(['council_reference'], record)
+    #ScraperWiki.save_sqlite(['council_reference'], record)
   end
 end
 


### PR DESCRIPTION
This scraper was failing as Cardinia have recently started to include N/A in the "on_notice_to" field, where a date is expected.

A more intelligent check can be included to potentially omit these records and check again next time, but for now this will ensure data from Cardinia is included on the site again.